### PR TITLE
fix(screenshare): properly cancel on user request

### DIFF
--- a/src/screencast/mod.rs
+++ b/src/screencast/mod.rs
@@ -163,13 +163,9 @@ impl ScreenCastInterface {
                     session.output_name = None;
                     session.window_id = Some(id);
                 }
-                None if session.source_type & 2 != 0 => {
-                    return Err(fdo::Error::Failed("user cancelled selection".into()));
-                }
                 None => {
-                    session.source_type = 1;
-                    session.output_name = niri_ipc::focused_output_name().ok();
-                    session.window_id = None;
+                    tracing::info!("SelectSources: user cancelled");
+                    return Ok((1, HashMap::new()));
                 }
             }
         } else {


### PR DESCRIPTION
Cancel was only treated as cancel when window capture was requested; otherwise it fell through to the focused monitor. It now always returns portal response 1 (user cancelled) and does not pick a default target.

Closes: #3 