### PR TITLE
Replace zenity with a GTK4 source picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -183,6 +183,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cairo-rs"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -274,10 +307,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -329,6 +392,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk4-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,10 +460,207 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "glib"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "graphene-rs"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b"
+dependencies = [
+ "glib",
+ "graphene-sys",
+ "libc",
+]
+
+[[package]]
+name = "graphene-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gsk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
+dependencies = [
+ "cairo-rs",
+ "gdk4",
+ "glib",
+ "graphene-rs",
+ "gsk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk4-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk4"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6"
+dependencies = [
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "graphene-rs",
+ "gsk4",
+ "gtk4-macros",
+ "gtk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "gsk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -383,6 +700,37 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libadwaita"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191"
+dependencies = [
+ "gdk4",
+ "gio",
+ "glib",
+ "gtk4",
+ "libadwaita-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "libadwaita-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db"
+dependencies = [
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "libc"
@@ -425,7 +773,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -434,6 +782,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures-util",
+ "gtk4",
+ "libadwaita",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -446,7 +796,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -463,6 +813,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "pango"
+version = "0.20.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -489,6 +863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +879,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -536,6 +916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +934,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -553,6 +942,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -596,6 +991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,7 +1037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -659,6 +1063,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,7 +1091,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -694,7 +1117,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -706,6 +1129,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -737,6 +1175,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -803,7 +1247,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -828,6 +1272,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "wasi"
@@ -888,12 +1338,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -933,7 +1456,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,17 @@ edition = "2021"
 
 [features]
 default = []
-picker = []
+picker = ["dep:gtk4", "dep:libadwaita"]
 
 [dependencies]
 zbus = { version = "5", features = ["tokio"] }
-tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
+tokio = { version = "1", features = ["rt", "macros", "time", "sync", "rt-multi-thread"] }
 futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 anyhow = "1"
+gtk4 = { version = "0.9", optional = true }
+libadwaita = { version = "0.7", optional = true }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ no manual config needed — `portals.conf` is written on first service start.
 
 **dynamic cast (default)** — auto-selects the focused output. change targets anytime via niri keybinds (`set-dynamic-cast-monitor`, `set-dynamic-cast-window`). for more read the wiki https://niri-wm.github.io/niri/Screencasting.html#dynamic-screencast-target
 
-**picker mode** — build with `--features picker` and set `NIRI_SCREENSHARE_PICKER=1` to get a zenity dialog with monitors and windows.
+**picker mode** — build with `--features picker` and set `NIRI_SCREENSHARE_PICKER=1` to get a GTK4 dialog with Displays / Windows tabs.
 
 | build | behavior | size |
 |-------|----------|------|
-| default | dynamic cast, no dialog | 1.5 MB |
-| `--features picker` | + optional zenity picker | 1.5 MB |
+| default | dynamic cast, no dialog | 2.1 MB |
+| `--features picker` | + optional GTK4 picker | 2.2 MB |
+
+Debug the picker UI without starting a cast:
+
+```
+cargo run --features picker -- --debug-picker
+```
 
 ## how
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
   rustPlatform,
-  makeWrapper,
-  zenity,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  libadwaita,
   withPicker ? true,
 }:
 
@@ -24,13 +26,19 @@ rustPlatform.buildRustPackage {
 
   buildFeatures = lib.optional withPicker "picker";
 
-  nativeBuildInputs = lib.optionals withPicker [ makeWrapper ];
+  nativeBuildInputs = lib.optionals withPicker [
+    pkg-config
+    wrapGAppsHook4
+  ];
 
+  buildInputs = lib.optionals withPicker [
+    gtk4
+    libadwaita
+  ];
+
+  # Start the GApps-wrapped $out/bin binary (schemas via XDG_DATA_DIRS).
   postInstall = ''
-    mkdir -p $out/lib $out/bin $out/share/dbus-1/services $out/lib/systemd/user
-
-    mv $out/bin/niri-screenshare $out/lib/niri-screenshare
-    ln -sf $out/lib/niri-screenshare $out/bin/niri-screenshare
+    mkdir -p $out/share/dbus-1/services $out/lib/systemd/user
 
     install -Dm644 data/niri.portal \
       $out/share/xdg-desktop-portal/portals/niri.portal
@@ -40,15 +48,11 @@ rustPlatform.buildRustPackage {
 
     substitute data/org.freedesktop.impl.portal.desktop.niri.service \
       $out/share/dbus-1/services/org.freedesktop.impl.portal.desktop.niri.service \
-      --replace-fail /usr/lib/niri-screenshare "$out/lib/niri-screenshare"
+      --replace-fail /usr/lib/niri-screenshare "$out/bin/niri-screenshare"
 
     substitute data/niri-screenshare.service \
       $out/lib/systemd/user/niri-screenshare.service \
-      --replace-fail /usr/lib/niri-screenshare "$out/lib/niri-screenshare"
-  ''
-  + lib.optionalString withPicker ''
-    wrapProgram $out/lib/niri-screenshare \
-      --prefix PATH : ${lib.makeBinPath [ zenity ]}
+      --replace-fail /usr/lib/niri-screenshare "$out/bin/niri-screenshare"
   '';
 
   meta = {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,7 +6,9 @@
   clippy,
   rust-analyzer,
   rustPlatform,
-  zenity,
+  pkg-config,
+  gtk4,
+  libadwaita,
   nixfmt,
   niri-screenshare,
 }:
@@ -20,7 +22,9 @@ mkShell {
     rustfmt
     clippy
     rust-analyzer
-    zenity
+    pkg-config
+    gtk4
+    libadwaita
     nixfmt
   ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,47 @@ mod niri_ipc;
 mod portal_config;
 mod screencast;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        .with_writer(std::io::stderr)
         .init();
 
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("--picker") | Some("--debug-picker") => {
+            #[cfg(feature = "picker")]
+            {
+                // No tokio: GTK needs the main thread. Choice on stdout, logs on stderr.
+                match screencast::run_picker_process() {
+                    Some(screencast::DebugPickerChoice::Monitor(name)) => {
+                        println!("M:{name}");
+                    }
+                    Some(screencast::DebugPickerChoice::Window(id)) => {
+                        println!("W:{id}");
+                    }
+                    None => {
+                        std::process::exit(1);
+                    }
+                }
+                return Ok(());
+            }
+            #[cfg(not(feature = "picker"))]
+            {
+                anyhow::bail!("--picker requires building with --features picker");
+            }
+        }
+        Some(arg) => {
+            anyhow::bail!(
+                "unknown argument: {arg}\nusage: niri-screenshare [--picker|--debug-picker]"
+            );
+        }
+        None => run_portal(),
+    }
+}
+
+#[tokio::main]
+async fn run_portal() -> anyhow::Result<()> {
     tracing::info!("starting niri-screenshare");
     portal_config::ensure_portals_config();
 

--- a/src/niri_ipc.rs
+++ b/src/niri_ipc.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::Command;
 
 pub struct Size {
@@ -10,8 +11,27 @@ pub struct NiriOutput {
     pub logical: Size,
 }
 
+fn niri_command() -> Command {
+    Command::new(niri_bin())
+}
+
+/// Resolve `niri` when PATH is minimal (systemd user services).
+pub fn niri_bin() -> &'static str {
+    const CANDIDATES: &[&str] = &[
+        "/run/current-system/sw/bin/niri",
+        "/usr/bin/niri",
+        "niri",
+    ];
+    for candidate in CANDIDATES {
+        if *candidate == "niri" || Path::new(candidate).is_file() {
+            return candidate;
+        }
+    }
+    "niri"
+}
+
 pub fn list_outputs() -> anyhow::Result<Vec<NiriOutput>> {
-    let out = Command::new("niri")
+    let out = niri_command()
         .args(["msg", "--json", "outputs"])
         .output()?;
     if !out.status.success() {
@@ -30,7 +50,7 @@ pub struct NiriWindow {
 }
 
 pub fn list_windows() -> anyhow::Result<Vec<NiriWindow>> {
-    let out = Command::new("niri")
+    let out = niri_command()
         .args(["msg", "--json", "windows"])
         .output()?;
     if !out.status.success() {
@@ -41,7 +61,7 @@ pub fn list_windows() -> anyhow::Result<Vec<NiriWindow>> {
 }
 
 pub fn focused_output_name() -> anyhow::Result<String> {
-    let out = Command::new("niri")
+    let out = niri_command()
         .args(["msg", "--json", "focused-output"])
         .output()?;
     if !out.status.success() {

--- a/src/screencast/mod.rs
+++ b/src/screencast/mod.rs
@@ -2,9 +2,15 @@
 mod pick;
 mod pw_backend;
 
+#[cfg(feature = "picker")]
+pub use pick::{
+    run_picker_process, show_picker as debug_show_picker, PickerChoice as DebugPickerChoice,
+};
+
 use std::collections::HashMap;
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tokio::sync::Mutex;
 use zbus::fdo;
@@ -17,9 +23,15 @@ use crate::niri_ipc;
 const MUTTER_SCREENCAST_DEST: &str = "org.gnome.Mutter.ScreenCast";
 const MUTTER_SCREENCAST_PATH: &str = "/org/gnome/Mutter/ScreenCast";
 
+/// How long to reuse a picker choice across client session retries.
+#[cfg(feature = "picker")]
+const PICKER_REUSE_TTL: Duration = Duration::from_secs(10);
+
 pub struct ScreenCastInterface {
     state: Arc<Mutex<HashMap<String, CaptureSession>>>,
     conn: Option<Connection>,
+    #[cfg(feature = "picker")]
+    picker: Arc<PickerCoordinator>,
 }
 
 struct CaptureSession {
@@ -37,6 +49,98 @@ struct SessionHandler {
     state: Arc<Mutex<HashMap<String, CaptureSession>>>,
     session_id: String,
     conn: Option<Connection>,
+    #[cfg(feature = "picker")]
+    picker: Arc<PickerCoordinator>,
+}
+
+/// In-flight picker child plus a short-lived selection cache for retrying clients.
+#[cfg(feature = "picker")]
+struct PickerCoordinator {
+    child: pick::PickerChildSlot,
+    picking_session: std::sync::Mutex<Option<String>>,
+    recent: std::sync::Mutex<Option<RecentPickerChoice>>,
+}
+
+#[cfg(feature = "picker")]
+struct RecentPickerChoice {
+    at: Instant,
+    app_id: String,
+    choice: pick::PickerChoice,
+}
+
+#[cfg(feature = "picker")]
+impl PickerCoordinator {
+    fn new() -> Self {
+        Self {
+            child: Arc::new(std::sync::Mutex::new(None)),
+            picking_session: std::sync::Mutex::new(None),
+            recent: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn take_reusable(&self, app_id: &str) -> Option<pick::PickerChoice> {
+        let guard = self.recent.lock().ok()?;
+        let recent = guard.as_ref()?;
+        if recent.at.elapsed() > PICKER_REUSE_TTL {
+            return None;
+        }
+        // Empty app_id on either side still matches.
+        if !recent.app_id.is_empty()
+            && !app_id.is_empty()
+            && recent.app_id != app_id
+        {
+            return None;
+        }
+        tracing::info!(
+            "reusing picker choice from {}s ago (app_id={:?})",
+            recent.at.elapsed().as_secs(),
+            app_id
+        );
+        Some(recent.choice.clone())
+    }
+
+    fn remember(&self, app_id: &str, choice: pick::PickerChoice) {
+        if let Ok(mut guard) = self.recent.lock() {
+            *guard = Some(RecentPickerChoice {
+                at: Instant::now(),
+                app_id: app_id.to_string(),
+                choice,
+            });
+        }
+    }
+
+    fn clear_recent(&self) {
+        if let Ok(mut guard) = self.recent.lock() {
+            *guard = None;
+        }
+    }
+
+    fn begin_picking(&self, session_id: &str) {
+        if let Ok(mut guard) = self.picking_session.lock() {
+            *guard = Some(session_id.to_string());
+        }
+    }
+
+    fn end_picking(&self, session_id: &str) {
+        if let Ok(mut guard) = self.picking_session.lock() {
+            if guard.as_deref() == Some(session_id) {
+                *guard = None;
+            }
+        }
+    }
+
+    fn cancel_if_picking(&self, session_id: &str) {
+        let ours = self
+            .picking_session
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .is_some_and(|s| s == session_id);
+        if ours {
+            pick::kill_slotted_picker(&self.child);
+            self.end_picking(session_id);
+        }
+    }
 }
 
 impl ScreenCastInterface {
@@ -44,6 +148,8 @@ impl ScreenCastInterface {
         Self {
             state: Arc::new(Mutex::new(HashMap::new())),
             conn: Some(conn),
+            #[cfg(feature = "picker")]
+            picker: Arc::new(PickerCoordinator::new()),
         }
     }
 }
@@ -52,6 +158,8 @@ impl ScreenCastInterface {
 impl SessionHandler {
     async fn close(&mut self) -> fdo::Result<()> {
         tracing::info!("Session.Close: session={}", self.session_id);
+        #[cfg(feature = "picker")]
+        self.picker.cancel_if_picking(&self.session_id);
         let mut state = self.state.lock().await;
         if let Some(session) = state.remove(&self.session_id) {
             Self::stop_niri(&self.conn, &session.niri_session_path).await;
@@ -78,7 +186,10 @@ impl ScreenCastInterface {
     #[zbus(property)]
     fn available_source_types(&self) -> u32 { 3 }
     #[zbus(property)]
-    fn available_cursor_modes(&self) -> u32 { 7 }
+    fn available_cursor_modes(&self) -> u32 {
+        // Hidden | Embedded. Skip Metadata, Electron often blacks out with it.
+        1 | 2
+    }
 
     async fn create_session(
         &mut self,
@@ -106,6 +217,8 @@ impl ScreenCastInterface {
                     state: self.state.clone(),
                     session_id: sh.clone(),
                     conn: self.conn.clone(),
+                    #[cfg(feature = "picker")]
+                    picker: self.picker.clone(),
                 }).await;
             }
         }
@@ -116,7 +229,7 @@ impl ScreenCastInterface {
         &mut self,
         _request_handle: ObjectPath<'_>,
         session_handle: ObjectPath<'_>,
-        _app_id: &str,
+        app_id: &str,
         options: HashMap<String, OwnedValue>,
     ) -> fdo::Result<(u32, HashMap<String, OwnedValue>)> {
         tracing::info!("SelectSources: session={}", session_handle);
@@ -130,14 +243,12 @@ impl ScreenCastInterface {
             }
         }
 
-        // Map portal cursor_mode to niri's values:
-        // portal: 1=Hidden, 2=Embedded, 4=Metadata
-        // niri:   0=Hidden, 1=Embedded, 2=Metadata
+        // portal: 1=Hidden 2=Embedded 4=Metadata; niri: 0=Hidden 1=Embedded 2=Metadata
         let cursor_portal = options.get("cursor_mode").and_then(val_u32);
+        // Prefer Embedded. Metadata often yields a black frame in Electron.
         let cursor_niri = match cursor_portal {
-            Some(2) => 1, // portal Embedded → niri Embedded
-            Some(4) => 2, // portal Metadata → niri Metadata
-            _ => 1,       // default: Embedded
+            Some(1) => 0,
+            _ => 1,
         };
 
         let mut state = self.state.lock().await;
@@ -150,42 +261,79 @@ impl ScreenCastInterface {
 
         #[cfg(feature = "picker")]
         if std::env::var("NIRI_SCREENSHARE_PICKER").is_ok() {
-            let outputs = niri_ipc::list_outputs().ok().unwrap_or_default();
-            let windows = niri_ipc::list_windows().ok().unwrap_or_default();
-            match pick::show_picker(&outputs, &windows) {
-                Some(pick::PickerChoice::Monitor(name)) => {
-                    session.source_type = 1;
-                    session.output_name = Some(name);
-                    session.window_id = None;
+            let session_id = session_handle.to_string();
+            let app_id = app_id.to_string();
+
+            // Reuse a recent choice so retrying clients only see one dialog.
+            let reused = self.picker.take_reusable(&app_id);
+            if let Some(choice) = reused {
+                apply_picker_choice(session, choice);
+                drop(state);
+                return Ok((0, select_sources_results()));
+            }
+
+            drop(state);
+
+            let outputs = match niri_ipc::list_outputs() {
+                Ok(o) => o,
+                Err(e) => {
+                    tracing::error!("list_outputs failed: {e}");
+                    Vec::new()
                 }
-                Some(pick::PickerChoice::Window(id)) => {
-                    session.source_type = 2;
-                    session.output_name = None;
-                    session.window_id = Some(id);
+            };
+            let windows = match niri_ipc::list_windows() {
+                Ok(w) => w,
+                Err(e) => {
+                    tracing::error!("list_windows failed: {e}");
+                    Vec::new()
+                }
+            };
+            tracing::info!(
+                "picker targets: {} display(s), {} window(s)",
+                outputs.len(),
+                windows.len()
+            );
+
+            self.picker.begin_picking(&session_id);
+            let child_slot = self.picker.child.clone();
+            let choice = tokio::task::spawn_blocking(move || {
+                pick::show_picker_cancellable(&outputs, &windows, Some(child_slot))
+            })
+            .await
+            .map_err(|e| fdo::Error::Failed(format!("picker task failed: {e}")))?;
+            self.picker.end_picking(&session_id);
+
+            let mut state = self.state.lock().await;
+            let session = state.get_mut(session_handle.as_str()).ok_or_else(|| {
+                fdo::Error::Failed(format!("session {} not found", session_handle))
+            })?;
+
+            match choice {
+                Some(choice) => {
+                    self.picker.remember(&app_id, choice.clone());
+                    apply_picker_choice(session, choice);
                 }
                 None => {
+                    // response 1 = user cancelled
+                    self.picker.clear_recent();
                     tracing::info!("SelectSources: user cancelled");
                     return Ok((1, HashMap::new()));
                 }
             }
-        } else {
-            session.output_name = niri_ipc::focused_output_name().ok()
-                .or_else(|| niri_ipc::list_outputs().ok()?.into_iter().next().map(|o| o.name));
+
+            tracing::info!("cursor={} source={} output={:?} window={:?}",
+                cursor_niri, session.source_type, session.output_name, session.window_id);
+
+            return Ok((0, select_sources_results()));
         }
 
-        #[cfg(not(feature = "picker"))]
-        {
-            session.output_name = niri_ipc::focused_output_name().ok()
-                .or_else(|| niri_ipc::list_outputs().ok()?.into_iter().next().map(|o| o.name));
-        }
+        session.output_name = niri_ipc::focused_output_name().ok()
+            .or_else(|| niri_ipc::list_outputs().ok()?.into_iter().next().map(|o| o.name));
 
         tracing::info!("cursor={} source={} output={:?} window={:?}",
             cursor_niri, session.source_type, session.output_name, session.window_id);
 
-        let mut results = HashMap::new();
-        results.insert("available_source_types".into(), OwnedValue::from(3u32));
-        results.insert("available_cursor_modes".into(), OwnedValue::from(7u32));
-        Ok((0, results))
+        Ok((0, select_sources_results()))
     }
 
     async fn start(
@@ -257,9 +405,10 @@ impl ScreenCastInterface {
     #[zbus(name = "OpenPipeWireRemote")]
     async fn open_pipewire_remote(
         &mut self,
-        _session_handle: ObjectPath<'_>,
+        session_handle: ObjectPath<'_>,
         _options: HashMap<String, OwnedValue>,
     ) -> fdo::Result<ZvariantFd<'static>> {
+        tracing::info!("OpenPipeWireRemote: session={}", session_handle);
         let raw = pw_backend::open_fd()
             .map_err(|e| fdo::Error::Failed(format!("open pipewire socket: {e}")))?;
         Ok(ZvariantFd::Owned(unsafe { OwnedFd::from_raw_fd(raw) }))
@@ -277,6 +426,29 @@ impl ScreenCastInterface {
             SessionHandler::stop_niri(&self.conn, &session.niri_session_path).await;
         }
         Ok(())
+    }
+}
+
+fn select_sources_results() -> HashMap<String, OwnedValue> {
+    let mut results = HashMap::new();
+    results.insert("available_source_types".into(), OwnedValue::from(3u32));
+    results.insert("available_cursor_modes".into(), OwnedValue::from(3u32));
+    results
+}
+
+#[cfg(feature = "picker")]
+fn apply_picker_choice(session: &mut CaptureSession, choice: pick::PickerChoice) {
+    match choice {
+        pick::PickerChoice::Monitor(name) => {
+            session.source_type = 1;
+            session.output_name = Some(name);
+            session.window_id = None;
+        }
+        pick::PickerChoice::Window(id) => {
+            session.source_type = 2;
+            session.output_name = None;
+            session.window_id = Some(id);
+        }
     }
 }
 

--- a/src/screencast/pick.rs
+++ b/src/screencast/pick.rs
@@ -1,70 +1,622 @@
+use std::cell::RefCell;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use gtk4::gdk::Display;
+use gtk4::gio;
+use gtk4::glib;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Application, ApplicationWindow, Box as GtkBox, CssProvider, Label, ListBox, Orientation,
+    PolicyType, ScrolledWindow, SelectionMode, STYLE_PROVIDER_PRIORITY_APPLICATION,
+};
+use libadwaita::prelude::*;
+use libadwaita::{ActionRow, HeaderBar, ViewStack, ViewSwitcher, ViewSwitcherPolicy};
+
 use crate::niri_ipc::{NiriOutput, NiriWindow};
 
+const PICKER_APP_ID: &str = "io.github.niri.screenshare.picker";
+
+#[derive(Debug, Clone)]
 pub enum PickerChoice {
     Monitor(String),
     Window(u64),
 }
 
-pub fn show_picker(
+#[derive(Clone)]
+struct DisplayItem {
+    name: String,
+    width: i32,
+    height: i32,
+}
+
+#[derive(Clone)]
+struct WindowItem {
+    id: u64,
+    title: String,
+    app_id: String,
+    width: i32,
+    height: i32,
+}
+
+/// Holds the picker child so Session.Close can kill it on cancel/retry.
+pub type PickerChildSlot = Arc<std::sync::Mutex<Option<std::process::Child>>>;
+
+/// Spawn `--picker` in a child process (GTK needs its own Application).
+pub fn show_picker(outputs: &[NiriOutput], windows: &[NiriWindow]) -> Option<PickerChoice> {
+    show_picker_cancellable(outputs, windows, None)
+}
+
+pub fn show_picker_cancellable(
     outputs: &[NiriOutput],
     windows: &[NiriWindow],
+    child_slot: Option<PickerChildSlot>,
 ) -> Option<PickerChoice> {
-    let monitor_count = outputs.len();
-    let window_count = windows.len();
-    if monitor_count + window_count == 0 {
+    let displays: Vec<DisplayItem> = outputs.iter().map(DisplayItem::from).collect();
+    let wins: Vec<WindowItem> = windows.iter().map(WindowItem::from).collect();
+
+    if displays.is_empty() && wins.is_empty() {
         return None;
     }
-    if monitor_count + window_count == 1 {
-        if let Some(o) = outputs.first() {
-            return Some(PickerChoice::Monitor(o.name.clone()));
+    if displays.len() + wins.len() == 1 {
+        if let Some(d) = displays.first() {
+            return Some(PickerChoice::Monitor(d.name.clone()));
         }
-        if let Some(w) = windows.first() {
+        if let Some(w) = wins.first() {
             return Some(PickerChoice::Window(w.id));
         }
     }
 
-    let mut cmd = std::process::Command::new("zenity");
-    cmd.arg("--list");
-    cmd.arg("--title=Screen Sharing");
-    cmd.arg("--text=Select what to share:");
-    cmd.arg("--column=ID");
-    cmd.arg("--column=Type");
-    cmd.arg("--column=Name");
-    cmd.arg("--column=Size");
-    cmd.arg("--print-column=1");
+    let bin = picker_bin();
+    let mut child = match Command::new(&bin)
+        .arg("--picker")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("failed to spawn picker {}: {e}", bin.display());
+            return None;
+        }
+    };
 
-    for o in outputs {
-        cmd.arg(format!("M:{}", o.name));
-        cmd.arg("Monitor");
-        cmd.arg(&o.name);
-        cmd.arg(format!("{}x{}", o.logical.width, o.logical.height));
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = write_picker_targets(&mut stdin, &displays, &wins) {
+            tracing::error!("failed to write picker targets: {e}");
+            let _ = child.kill();
+            return None;
+        }
     }
-    for w in windows {
-        let label = if w.title.is_empty() { &w.app_id } else { &w.title };
-        cmd.arg(format!("W:{}", w.id));
-        cmd.arg("Window");
-        cmd.arg(label);
-        cmd.arg(format!("{}x{}", w.size.width, w.size.height));
+
+    let stdout = child.stdout.take();
+
+    let status = if let Some(slot) = &child_slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(mut old) = guard.take() {
+                let _ = old.kill();
+                let _ = old.wait();
+            }
+            *guard = Some(child);
+        }
+
+        loop {
+            let finished = {
+                let mut guard = slot.lock().ok();
+                match guard.as_mut().and_then(|g| g.as_mut()) {
+                    Some(c) => match c.try_wait() {
+                        Ok(Some(status)) => Some(Ok(status)),
+                        Ok(None) => None,
+                        Err(e) => Some(Err(e)),
+                    },
+                    None => Some(Err(std::io::Error::other("picker killed"))),
+                }
+            };
+            match finished {
+                Some(result) => break result,
+                None => std::thread::sleep(Duration::from_millis(50)),
+            }
+        }
+    } else {
+        child.wait()
+    };
+
+    if let Some(slot) = &child_slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(mut c) = guard.take() {
+                let _ = c.wait();
+            }
+        }
     }
 
-    cmd.arg("--width=600");
-    cmd.arg("--height=400");
+    let status = match status {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::info!("picker wait ended: {e}");
+            return None;
+        }
+    };
 
-    let out = cmd.output().ok()?;
-    if !out.status.success() {
+    if !status.success() {
+        tracing::info!("picker exited with {status}");
         return None;
     }
-    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if s.is_empty() {
+
+    let Some(stdout) = stdout else {
         return None;
-    }
-    if let Some(name) = s.strip_prefix("M:") {
-        return Some(PickerChoice::Monitor(name.to_string()));
-    }
-    if let Some(id_str) = s.strip_prefix("W:") {
-        if let Ok(id) = id_str.parse::<u64>() {
-            return Some(PickerChoice::Window(id));
+    };
+    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if let Some(name) = line.strip_prefix("M:") {
+            return Some(PickerChoice::Monitor(name.to_string()));
+        }
+        if let Some(id) = line.strip_prefix("W:") {
+            if let Ok(id) = id.parse::<u64>() {
+                return Some(PickerChoice::Window(id));
+            }
         }
     }
     None
+}
+
+pub fn kill_slotted_picker(slot: &PickerChildSlot) {
+    if let Ok(mut guard) = slot.lock() {
+        if let Some(mut child) = guard.take() {
+            tracing::info!("killing in-flight picker pid={}", child.id());
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// CLI entry for `--picker` / `--debug-picker`. Targets from stdin, else niri IPC.
+pub fn run_picker_process() -> Option<PickerChoice> {
+    let (displays, windows) = read_targets_or_query_niri();
+    run_gtk_application(displays, windows)
+}
+
+fn picker_bin() -> PathBuf {
+    // Prefer argv[0] so a Nix GApps wrapper is reused when packaged.
+    if let Some(arg0) = std::env::args_os().next() {
+        let p = PathBuf::from(arg0);
+        if p.exists() {
+            return p;
+        }
+    }
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("niri-screenshare"))
+}
+
+fn write_picker_targets(
+    out: &mut impl Write,
+    displays: &[DisplayItem],
+    windows: &[WindowItem],
+) -> std::io::Result<()> {
+    // D:name\tw\th  W:id\ttitle\tapp\tw\th  END
+    for d in displays {
+        writeln!(out, "D:{}\t{}\t{}", escape_field(&d.name), d.width, d.height)?;
+    }
+    for w in windows {
+        writeln!(
+            out,
+            "W:{}\t{}\t{}\t{}\t{}",
+            w.id,
+            escape_field(&w.title),
+            escape_field(&w.app_id),
+            w.width,
+            w.height
+        )?;
+    }
+    writeln!(out, "END")?;
+    out.flush()
+}
+
+fn escape_field(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+}
+
+fn unescape_field(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('t') => out.push('\t'),
+                Some('n') => out.push('\n'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn read_targets_or_query_niri() -> (Vec<DisplayItem>, Vec<WindowItem>) {
+    if let Some(targets) = read_targets_from_stdin() {
+        return targets;
+    }
+    let displays = crate::niri_ipc::list_outputs()
+        .unwrap_or_default()
+        .iter()
+        .map(DisplayItem::from)
+        .collect();
+    let windows = crate::niri_ipc::list_windows()
+        .unwrap_or_default()
+        .iter()
+        .map(WindowItem::from)
+        .collect();
+    (displays, windows)
+}
+
+fn read_targets_from_stdin() -> Option<(Vec<DisplayItem>, Vec<WindowItem>)> {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        return None;
+    }
+    let mut displays = Vec::new();
+    let mut windows = Vec::new();
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines().map_while(Result::ok) {
+        let line = line.trim_end().to_string();
+        if line == "END" {
+            return Some((displays, windows));
+        }
+        if let Some(rest) = line.strip_prefix("D:") {
+            let parts: Vec<&str> = rest.split('\t').collect();
+            if parts.len() >= 3 {
+                displays.push(DisplayItem {
+                    name: unescape_field(parts[0]),
+                    width: parts[1].parse().unwrap_or(0),
+                    height: parts[2].parse().unwrap_or(0),
+                });
+            }
+        } else if let Some(rest) = line.strip_prefix("W:") {
+            let parts: Vec<&str> = rest.split('\t').collect();
+            if parts.len() >= 5 {
+                if let Ok(id) = parts[0].parse::<u64>() {
+                    windows.push(WindowItem {
+                        id,
+                        title: unescape_field(parts[1]),
+                        app_id: unescape_field(parts[2]),
+                        width: parts[3].parse().unwrap_or(0),
+                        height: parts[4].parse().unwrap_or(0),
+                    });
+                }
+            }
+        }
+    }
+    if displays.is_empty() && windows.is_empty() {
+        None
+    } else {
+        Some((displays, windows))
+    }
+}
+
+fn run_gtk_application(
+    displays: Vec<DisplayItem>,
+    windows: Vec<WindowItem>,
+) -> Option<PickerChoice> {
+    let result: Rc<RefCell<Option<PickerChoice>>> = Rc::new(RefCell::new(None));
+
+    let app = Application::builder()
+        .application_id(PICKER_APP_ID)
+        .flags(gio::ApplicationFlags::NON_UNIQUE)
+        .build();
+
+    let result_activate = result.clone();
+    app.connect_activate(move |app| {
+        build_and_present(app, displays.clone(), windows.clone(), result_activate.clone());
+    });
+
+    let exit = app.run_with_args::<&str>(&[]);
+    if exit != glib::ExitCode::SUCCESS {
+        tracing::warn!("picker gtk application exited with {exit:?}");
+    }
+
+    let choice = result.borrow().clone();
+    choice
+}
+
+fn build_and_present(
+    app: &Application,
+    displays: Vec<DisplayItem>,
+    windows: Vec<WindowItem>,
+    result: Rc<RefCell<Option<PickerChoice>>>,
+) {
+    let _ = libadwaita::init();
+
+    let selection: Rc<RefCell<Option<PickerChoice>>> = Rc::new(RefCell::new(None));
+
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("Screen Sharing")
+        .default_width(520)
+        .default_height(480)
+        .build();
+
+    let header = HeaderBar::new();
+
+    let stack = ViewStack::new();
+    stack.set_vexpand(true);
+
+    let switcher = ViewSwitcher::builder()
+        .stack(&stack)
+        .policy(ViewSwitcherPolicy::Wide)
+        .build();
+    header.set_title_widget(Some(&switcher));
+
+    let display_list = build_display_list(&displays, &selection);
+    let display_scroll = ScrolledWindow::builder()
+        .child(&display_list)
+        .hscrollbar_policy(PolicyType::Never)
+        .vexpand(true)
+        .build();
+    let displays_page = stack.add_titled(&display_scroll, Some("displays"), "Displays");
+    displays_page.set_icon_name(Some("video-display-symbolic"));
+
+    let window_list = build_window_list(&windows, &selection);
+    let window_scroll = ScrolledWindow::builder()
+        .child(&window_list)
+        .hscrollbar_policy(PolicyType::Never)
+        .vexpand(true)
+        .build();
+    let windows_page = stack.add_titled(&window_scroll, Some("windows"), "Windows");
+    windows_page.set_icon_name(Some("window-symbolic"));
+
+    let cancel = gtk4::Button::with_label("Cancel");
+    cancel.add_css_class("pill");
+    let share = gtk4::Button::with_label("Share");
+    share.add_css_class("pill");
+    share.add_css_class("suggested-action");
+    share.set_sensitive(false);
+
+    let share_btn = share.clone();
+    let selection_watch = selection.clone();
+    glib::timeout_add_local(Duration::from_millis(100), move || {
+        share_btn.set_sensitive(selection_watch.borrow().is_some());
+        glib::ControlFlow::Continue
+    });
+
+    let button_row = GtkBox::new(Orientation::Horizontal, 12);
+    button_row.set_halign(Align::End);
+    button_row.set_margin_top(6);
+    button_row.set_margin_bottom(12);
+    button_row.set_margin_start(12);
+    button_row.set_margin_end(12);
+    button_row.append(&cancel);
+    button_row.append(&share);
+
+    let content = GtkBox::new(Orientation::Vertical, 0);
+    content.append(&header);
+    content.append(&stack);
+    content.append(&button_row);
+    window.set_child(Some(&content));
+
+    let finish = Rc::new({
+        let result = result.clone();
+        let selection = selection.clone();
+        let window = window.clone();
+        move |accepted: bool| {
+            if accepted {
+                *result.borrow_mut() = selection.borrow().clone();
+            }
+            window.close();
+        }
+    });
+
+    cancel.connect_clicked({
+        let finish = finish.clone();
+        move |_| finish(false)
+    });
+    share.connect_clicked({
+        let finish = finish.clone();
+        let selection = selection.clone();
+        move |_| {
+            if selection.borrow().is_some() {
+                finish(true);
+            }
+        }
+    });
+
+    display_list.connect_row_activated({
+        let finish = finish.clone();
+        let selection = selection.clone();
+        move |_, _| {
+            if selection.borrow().is_some() {
+                finish(true);
+            }
+        }
+    });
+    window_list.connect_row_activated({
+        let finish = finish.clone();
+        let selection = selection.clone();
+        move |_, _| {
+            if selection.borrow().is_some() {
+                finish(true);
+            }
+        }
+    });
+
+    if let Some(display) = Display::default() {
+        let provider = CssProvider::new();
+        provider.load_from_data("headerbar { min-height: 48px; }");
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &provider,
+            STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+    }
+
+    window.present();
+    glib::timeout_add_local_once(Duration::from_millis(50), focus_picker_on_niri);
+}
+
+fn build_display_list(
+    displays: &[DisplayItem],
+    selection: &Rc<RefCell<Option<PickerChoice>>>,
+) -> ListBox {
+    let list = ListBox::new();
+    list.set_selection_mode(SelectionMode::Single);
+    list.add_css_class("boxed-list");
+    list.set_margin_top(12);
+    list.set_margin_bottom(12);
+    list.set_margin_start(12);
+    list.set_margin_end(12);
+
+    if displays.is_empty() {
+        list.append(&empty_label("No displays found"));
+        return list;
+    }
+
+    for d in displays {
+        let row = ActionRow::builder()
+            .title(&d.name)
+            .subtitle(format!("{}×{}", d.width, d.height))
+            .activatable(true)
+            .selectable(true)
+            .build();
+        list.append(&row);
+    }
+
+    let items = displays.to_vec();
+    let selection = selection.clone();
+    list.connect_row_selected(move |_, row| {
+        let Some(row) = row else { return };
+        if let Some(d) = items.get(row.index() as usize) {
+            *selection.borrow_mut() = Some(PickerChoice::Monitor(d.name.clone()));
+        }
+    });
+
+    list
+}
+
+fn build_window_list(
+    windows: &[WindowItem],
+    selection: &Rc<RefCell<Option<PickerChoice>>>,
+) -> ListBox {
+    let list = ListBox::new();
+    list.set_selection_mode(SelectionMode::Single);
+    list.add_css_class("boxed-list");
+    list.set_margin_top(12);
+    list.set_margin_bottom(12);
+    list.set_margin_start(12);
+    list.set_margin_end(12);
+
+    if windows.is_empty() {
+        list.append(&empty_label("No windows found"));
+        return list;
+    }
+
+    for w in windows {
+        let title = if w.title.is_empty() {
+            w.app_id.clone()
+        } else {
+            w.title.clone()
+        };
+        let subtitle = if w.app_id.is_empty() || w.app_id == title {
+            format!("{}×{}", w.width, w.height)
+        } else {
+            format!("{} · {}×{}", w.app_id, w.width, w.height)
+        };
+        let row = ActionRow::builder()
+            .title(&title)
+            .subtitle(subtitle)
+            .activatable(true)
+            .selectable(true)
+            .build();
+        list.append(&row);
+    }
+
+    let items = windows.to_vec();
+    let selection = selection.clone();
+    list.connect_row_selected(move |_, row| {
+        let Some(row) = row else { return };
+        if let Some(w) = items.get(row.index() as usize) {
+            *selection.borrow_mut() = Some(PickerChoice::Window(w.id));
+        }
+    });
+
+    list
+}
+
+fn empty_label(text: &str) -> Label {
+    let label = Label::new(Some(text));
+    label.add_css_class("dim-label");
+    label.set_margin_top(24);
+    label.set_margin_bottom(24);
+    label.set_halign(Align::Center);
+    label
+}
+
+fn focus_picker_on_niri() {
+    focus_picker_on_niri_attempt(0);
+}
+
+fn focus_picker_on_niri_attempt(attempt: u32) {
+    if try_float_picker_window() || attempt >= 20 {
+        return;
+    }
+    glib::timeout_add_local_once(Duration::from_millis(50), move || {
+        focus_picker_on_niri_attempt(attempt + 1);
+    });
+}
+
+fn try_float_picker_window() -> bool {
+    let Ok(windows) = crate::niri_ipc::list_windows() else {
+        return false;
+    };
+    let Some(w) = windows.iter().rev().find(|w| {
+        w.app_id == PICKER_APP_ID
+            || w.app_id.contains("screenshare.picker")
+            || w.app_id.contains("niri-screenshare-picker")
+            || w.title == "Screen Sharing"
+    }) else {
+        return false;
+    };
+    let id = w.id.to_string();
+    let niri = crate::niri_ipc::niri_bin();
+    let _ = Command::new(niri)
+        .args(["msg", "action", "focus-window", "--id", &id])
+        .output();
+    let _ = Command::new(niri)
+        .args(["msg", "action", "move-window-to-floating", "--id", &id])
+        .output();
+    let _ = Command::new(niri)
+        .args(["msg", "action", "center-window", "--id", &id])
+        .output();
+    true
+}
+
+impl From<&NiriOutput> for DisplayItem {
+    fn from(o: &NiriOutput) -> Self {
+        Self {
+            name: o.name.clone(),
+            width: o.logical.width,
+            height: o.logical.height,
+        }
+    }
+}
+
+impl From<&NiriWindow> for WindowItem {
+    fn from(w: &NiriWindow) -> Self {
+        Self {
+            id: w.id,
+            title: w.title.clone(),
+            app_id: w.app_id.clone(),
+            width: w.size.width,
+            height: w.size.height,
+        }
+    }
 }


### PR DESCRIPTION
This PR replaces the zenity-based picker with a GTK4 / libadwaita dialog behind `--features picker`.
Still gated the same way: build with `picker`, set `NIRI_SCREENSHARE_PICKER=1`.

### Notes from #7 

Addressed as requested:

- **Own module, non-blocking D-Bus** - UI lives in `src/screencast/pick.rs`. The portal process spawns `niri-screenshare --picker` as a child (via `spawn_blocking`), so GTK never owns the portal's event loop.
- **Same logic as zenity** - selection is still `M:output_name` / `W:window_id`, cancel still returns portal response `1`.
- **Tabs + libadwaita** - Displays / Windows tabs via `AdwViewStack` + `ViewSwitcher`.
- **OBS / Electron** - exercised with Vesktop (Electron). Cursor mode advertises Hidden|Embedded only (Metadata often blacks out Electron). Short reuse window (10s) so Electron session retries don't open the dialog three times (we can gladly adjust the time or perhaps find a better approach, I just thought it felt weird having to go through the picker 3 times until screensharing is finally invoked).

### Other details

- `--debug-picker` / `--picker` for standalone UI testing (no portal).
- Nix: `wrapGAppsHook4`, systemd/dbus start the wrapped `$out/bin` binary so GSettings schemas resolve.
- Binary size: ~2.1 MB default, ~2.2 MB with picker (plus GTK/libadwaita runtime deps).

I did **NOT** take a look at the PKGBUILD so this is something you would have to update.

### Screenshots

<img width="572" height="527" alt="image" src="https://github.com/user-attachments/assets/e74541e2-310c-4c38-87f7-1fd0fffe922e" />

<img width="572" height="527" alt="image" src="https://github.com/user-attachments/assets/d2df9f3d-349a-4a71-9c17-ad36e8207dba" />


## Test plan

- [x] `cargo build --features picker` / `nix build`
- [x] `niri-screenshare --debug-picker` opens Displays / Windows tabs
- [x] Cancel returns response `1`, no fallback monitor cast
- [x] Share a display and a window from Vesktop / Discord
- [x] Share from OBS
- [x] Second share soon after the first does not re-prompt (retry reuse)
- [x] NixOS: service uses `$out/bin/niri-screenshare` (GApps wrap), picker visible under systemd

As mentioned above, this was not tested with OBS since I currently don't have OBS set up, please do test this yourself.
Please do let me know if things should be changed etc, I'm rather inexperienced when it comes to working with xdg-portal related things.

Closes: #7 